### PR TITLE
Add CustomTempDirFactory and its test so JUnit places outputs anywhere but in /tmp

### DIFF
--- a/20_Test_Fixtures/my-build-logic/java-plugins/src/main/kotlin/my-java-library.gradle.kts
+++ b/20_Test_Fixtures/my-build-logic/java-plugins/src/main/kotlin/my-java-library.gradle.kts
@@ -8,3 +8,10 @@ val test = sourceSets.test.get()
 java.registerFeature(test.name) {
     usingSourceSet(test)
 }
+
+dependencies {
+    testFixturesImplementation("org.junit.jupiter:junit-jupiter-api")
+}
+dependencies {
+    testFixturesImplementation(platform("org.junit:junit-bom:6.0.2"))
+}

--- a/20_Test_Fixtures/my-project/business-logic/build.gradle.kts
+++ b/20_Test_Fixtures/my-project/business-logic/build.gradle.kts
@@ -12,3 +12,11 @@ dependencies {
     //     capabilities { requireCapability("org.example.my-app:data-model-test-fixtures") }
     // }
 }
+
+tasks.test {
+    testLogging {
+        showStandardStreams = true
+    }
+
+    systemProperty("test.tempdir.baseDir", layout.buildDirectory.dir("junit").get().asFile.absolutePath)
+}

--- a/20_Test_Fixtures/my-project/business-logic/src/test/java/myproject/services/ServiceTest.java
+++ b/20_Test_Fixtures/my-project/business-logic/src/test/java/myproject/services/ServiceTest.java
@@ -2,10 +2,24 @@ package myproject.services;
 
 import myproject.data.test.MessageModelFixture;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ServiceTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void verifyCustomFactory(@TempDir Path temp) {
+        System.out.println("Temp dir: " + temp);
+        assertTrue(temp.toString().contains("build/junit"),
+            "Expected temp dir under build/junit but got: " + temp);
+    }
 
     @Test
     void emoji_in_message_is_encoded() {

--- a/20_Test_Fixtures/my-project/data-model/src/testFixtures/java/myproject/data/test/CustomTempDirFactory.java
+++ b/20_Test_Fixtures/my-project/data-model/src/testFixtures/java/myproject/data/test/CustomTempDirFactory.java
@@ -1,0 +1,30 @@
+package myproject.data.test;
+
+import org.junit.jupiter.api.extension.AnnotatedElementContext;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.io.TempDirFactory;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class CustomTempDirFactory implements TempDirFactory {
+    @Override
+    public Path createTempDirectory(
+        AnnotatedElementContext elementContext,
+        ExtensionContext extensionContext
+    ) throws IOException
+    {
+        String baseDir = System.getProperty("test.tempdir.baseDir");
+        System.err.println("=== CustomTempDirFactory invoked ===");
+        System.err.println("test.tempdir.baseDir property: " + baseDir);
+        System.err.println("Current working dir: " + System.getProperty("user.dir"));
+
+        if (baseDir == null || baseDir.isEmpty()) {
+            throw new IllegalStateException("test.tempdir.baseDir not set!");
+        }
+        Path customBaseDir = Path.of(baseDir);
+        Files.createDirectories(customBaseDir); // Ensure the base directory exists
+        return Files.createTempDirectory(customBaseDir, "junit");
+    }
+}


### PR DESCRIPTION
Goal: Get JUnit `@TempDir` to put output files in `build/junit` folder.

I am attempting to use `testFixtures` to share a common `CustomTempDirFactory` class between many projects or sub-projects, but it never seems to load. After many attempts, I created this changeset as an example so other people can help me debug this issue (please!).

How to reproduce:
```
gradle --version
gradle test --tests="*.verifyCustomFactory"
```

Expected result:
The `CustomTempDirFactory` places the `@TempDir Path` under `build/junit`, the test passes.

Actual result:
The `@TempDir Path tempDir` is placed under `/tmp`, the `CustomTempDirFactory` is not used, the test fails.